### PR TITLE
Add Python particle filter prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Particle_Filter
-MATLAB implementation of standard particle filter, auxiliary particle filter, mixture particle filter, and out-of-sequence particle filter for terrain-referenced navigation
+MATLAB implementation of standard particle filter, auxiliary particle filter, mixture particle filter, and out-of-sequence particle filter for terrain-referenced navigation.
+
+This repository now also includes an experimental **Python** version of the basic particle filter located in `python/`.  The Python code mirrors the MATLAB example using NumPy and SciPy for interpolation and filtering utilities.
 
 How to run:
 
 run main_OOSM.m
+
+For the Python prototype:
+
+```bash
+python -m python.pf_main
+```
 
 
 Please cite the following paper if you find this code helpful:

--- a/python/pf_main.py
+++ b/python/pf_main.py
@@ -1,0 +1,84 @@
+"""Simplified Python implementation of the particle filter example."""
+from __future__ import annotations
+
+import numpy as np
+
+from .pf_utils import load_dem, dem_height, gaussian_likelihood, systematic_resample
+
+
+class ParticleFilter:
+    """Basic particle filter for terrain-referenced navigation."""
+
+    def __init__(self, dem: dict, num_particles: int = 500, dt: float = 1.0, sig_proc: float = 8.0, sig_meas: float = 25.0):
+        self.dem = dem
+        self.num_particles = num_particles
+        self.dt = dt
+        self.sig_proc = sig_proc
+        self.sig_meas = sig_meas
+
+        self.particles = np.zeros((2, num_particles))
+        self.weights = np.ones(num_particles) / num_particles
+
+    def initialize(self, init_mean: np.ndarray, init_std: float) -> None:
+        self.particles[:] = init_mean[:, None] + init_std * np.random.randn(2, self.num_particles)
+        self.weights[:] = np.ones(self.num_particles) / self.num_particles
+
+    def predict(self, v: np.ndarray) -> None:
+        noise = self.sig_proc * np.random.randn(2, self.num_particles) * self.dt
+        self.particles += (v[:, None] * self.dt) + noise
+
+    def update(self, z: float) -> None:
+        for i in range(self.num_particles):
+            z_est = dem_height(self.particles[:, i], self.dem)
+            self.weights[i] *= gaussian_likelihood(z_est, z, self.sig_meas)
+        self.weights /= np.sum(self.weights)
+        self.particles, self.weights = systematic_resample(self.particles, self.weights)
+
+    def estimate(self) -> np.ndarray:
+        return np.mean(self.particles, axis=1)
+
+
+def run_example(dem_path: str) -> None:
+    """Run the particle filter with synthetic data similar to the MATLAB demo."""
+    dem = load_dem(dem_path)
+    dt = 1.0
+    sim_time = 150
+    num_steps = int(sim_time / dt) + 1
+    time = np.arange(0, sim_time + dt, dt)
+
+    x_init = np.array([2600.0, 2800.0])
+    sig_init = 40.0
+    sig_v = 2.0
+    sig_z = 15 + 4.71
+
+    # generate simple trajectory
+    true_pos = np.zeros((2, num_steps))
+    true_pos[:, 0] = x_init
+    true_vel = np.zeros((2, num_steps - 1))
+    true_vel[:, :] = np.array([[42.0], [0.0]])
+    for k in range(1, num_steps):
+        true_pos[:, k] = true_pos[:, k - 1] + true_vel[:, k - 1] * dt
+
+    # noisy measurements
+    rng = np.random.default_rng()
+    z_meas = np.array([dem_height(true_pos[:, k], dem) + rng.normal(scale=sig_z) for k in range(num_steps)])
+    v_meas = true_vel + rng.normal(scale=sig_v, size=true_vel.shape)
+
+    pf = ParticleFilter(dem)
+    pf.initialize(x_init, sig_init)
+
+    est = np.zeros((2, num_steps))
+    est[:, 0] = pf.estimate()
+
+    for k in range(1, num_steps):
+        pf.predict(v_meas[:, k - 1])
+        pf.update(z_meas[k])
+        est[:, k] = pf.estimate()
+
+    # simple output: RMS error
+    err = np.linalg.norm(est - true_pos, axis=0)
+    print(f"RMS error: {np.sqrt(np.mean(err ** 2)):.2f} m")
+
+
+if __name__ == "__main__":
+    run_example("DB_part.mat")

--- a/python/pf_utils.py
+++ b/python/pf_utils.py
@@ -1,0 +1,60 @@
+"""Utility functions for particle filtering in Python."""
+from __future__ import annotations
+
+import numpy as np
+try:
+    from scipy.io import loadmat
+    from scipy.interpolate import RectBivariateSpline
+except Exception:  # pragma: no cover - SciPy may not be available
+    loadmat = None
+    RectBivariateSpline = None
+
+
+def load_dem(path: str) -> dict:
+    """Load DEM data from a .mat file returned as a dictionary."""
+    if loadmat is None:
+        raise ImportError("SciPy is required to load MATLAB files")
+    data = loadmat(path)
+    if 'DB' not in data or 'resolution' not in data:
+        raise KeyError("MAT file does not contain expected fields")
+    return {
+        'DB': data['DB'],
+        'resolution': float(data['resolution'].squeeze())
+    }
+
+
+def dem_height(pos: np.ndarray, dem: dict) -> float:
+    """Interpolate the DEM height at a given x, y position."""
+    if RectBivariateSpline is None:
+        raise ImportError("SciPy is required for interpolation")
+    x, y = pos
+    resolution = dem['resolution']
+    grid = dem['DB']
+    r, c = grid.shape
+    ix = int(np.floor(x / resolution))
+    iy = int(np.floor(y / resolution))
+    ix_idx = np.arange(ix - 2, ix + 3)
+    iy_idx = np.arange(iy - 2, iy + 3)
+    ix_idx = np.clip(ix_idx, 0, r - 1)
+    iy_idx = np.clip(iy_idx, 0, c - 1)
+    patch = grid[np.ix_(ix_idx, iy_idx)]
+    X = ix_idx * 1.0
+    Y = iy_idx * 1.0
+    interp = RectBivariateSpline(X, Y, patch, kx=3, ky=3)
+    return float(interp(x / resolution, y / resolution))
+
+
+def gaussian_likelihood(z_est: float, z_mea: float, sig: float) -> float:
+    """Gaussian likelihood of z_mea given estimate z_est."""
+    var = sig ** 2
+    return (1.0 / np.sqrt(2.0 * np.pi * var)) * np.exp(-((z_mea - z_est) ** 2) / (2.0 * var))
+
+
+def systematic_resample(particles: np.ndarray, weights: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Systematic resampling for particle filters."""
+    weights = weights / np.sum(weights)
+    cdf = np.cumsum(weights)
+    num = len(weights)
+    indexes = np.searchsorted(cdf, np.random.rand(num))
+    resampled = particles[:, indexes]
+    return resampled, np.ones(num) / num


### PR DESCRIPTION
## Summary
- add a simple Python prototype of the particle filter
- document Python prototype in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459dbebb688332922cd6a4e5592d82